### PR TITLE
Update sklearn to scikit-learn in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,6 @@ setup(
     install_requires=[
         "numpy",
         "python-weka-wrapper3>=0.2.5",
-        "sklearn",
+        "scikit-learn",
     ],
 )


### PR DESCRIPTION
Changed sklearn to scikit-learn as the name sklearn is deprecated and the package cannot be installed using pip.